### PR TITLE
SSL support fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 colorama==0.3.3
-Django==1.6
+Django==1.8
 django-autofixture==0.10.1
 django-nose==1.4.1
 django-tastypie==0.12.2
-django-tastypie-hmacauth==0.0.1b6
+django-tastypie-hmacauth==0.0.1b7
 nose==1.3.7
 pluggy==0.3.0
 py==1.4.30

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 colorama==0.3.3
-Django==1.6
+Django==1.8
 django-autofixture==0.10.1
 django-nose==1.4.1
 django-tastypie==0.12.2

--- a/tastypie_hmacauth/authentication.py
+++ b/tastypie_hmacauth/authentication.py
@@ -53,7 +53,7 @@ class HMACAuthentication(Authentication):
     def is_api_key_valid(self, api_key, request):
 
         protocol = 'http://'
-        if 'HTTPS' in request.META['SERVER_PROTOCOL']:
+        if 'https' in request.scheme:
             protocol = 'https://'
 
         host = request.META['HTTP_HOST'] if 'HTTP_HOST' in request.META else 'localhost' #ResourceTestCase api_client does not setn HTTP_HOST

--- a/test_project/rh/models.py
+++ b/test_project/rh/models.py
@@ -17,8 +17,8 @@ class Patrao(models.Model):
         ordering = ('data_de_cadastro',)  
     usuario = models.ForeignKey(User)
 
-    data_de_cadastro = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
-    data_de_atualizacao = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de atualizacao no Sistema", auto_now=True)
+    data_de_cadastro = models.DateTimeField(blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
+    data_de_atualizacao = models.DateTimeField(blank=True, null=True, verbose_name="data de atualizacao no Sistema", auto_now=True)
     def __unicode__(self):
         return u'%s' % (self.usuario.username)
 
@@ -41,16 +41,16 @@ class Funcionario(models.Model):
         )
     rg = models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2)  
     cpf = models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2)  
-    data_de_nascimento = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
+    data_de_nascimento = models.DateTimeField(blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
     telefone_residencial = models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2) 
     telefone_celular = models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2) 
     telefone_residencial = models.DecimalField(blank=True, null=True, max_digits=5, decimal_places=2) 
     email = models.EmailField(max_length=70,blank=True)
     cargo = models.CharField(max_length=100,blank=True)
-    data_de_admissao = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de admissao do funcionario", auto_now_add=True)
+    data_de_admissao = models.DateTimeField(blank=True, null=True, verbose_name="data de admissao do funcionario", auto_now_add=True)
   
-    data_de_cadastro = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
-    data_de_atualizacao = models.DateTimeField(default=datetime.now, blank=True, null=True, verbose_name="data de atualizacao no Sistema", auto_now=True)
+    data_de_cadastro = models.DateTimeField(blank=True, null=True, verbose_name="data de cadastro no Sistema", auto_now_add=True)
+    data_de_atualizacao = models.DateTimeField(blank=True, null=True, verbose_name="data de atualizacao no Sistema", auto_now=True)
     def __unicode__(self):
         return u'%s' % (self.nome)
 


### PR DESCRIPTION
Well, I tried to use SSL on my production environment, with valid SSL certificate, but with no success.
The parameter on checking if the connection is HTTPS was wrong and I fixed, validating on my production environment and it's working fine now.

I wrote more tests on test_project, simulating use of HTTPS, and all is passing. However, it's working on Django 1.8, and due to the dropped support of Django 1.6, I've updated the requirements instead of work on some compatible solution.